### PR TITLE
fix: Move the cross to prevent from deleting a query in the editor

### DIFF
--- a/warp/partials/query.editor.html
+++ b/warp/partials/query.editor.html
@@ -34,13 +34,14 @@
                   Move down
                 </a>
               </li>
+              <li role="menuitem">
+                <a  tabindex="1"
+                  ng-click="removeDataQuery(target)">
+                  Remove
+                </a>
+              </li>
             </ul>
           </div>
-        </li>
-        <li class="tight-form-item last">
-          <a class="pointer" tabindex="1" ng-click="removeDataQuery(target)">
-            <i class="fa fa-remove"></i>
-          </a>
         </li>
       </ul>
 


### PR DESCRIPTION
Close #1