### PR TITLE
Compatibility 2.5 enhancements

### DIFF
--- a/warp10/datasource.js
+++ b/warp10/datasource.js
@@ -7,7 +7,7 @@ define([
   './queryCtrl',
   './directives'
 ],
-function (angular, _, datemath, kbn) {
+function (angular, _, dateMath, kbn) {
   'use strict';
 
   var module = angular.module('grafana.services');
@@ -205,7 +205,7 @@ function (angular, _, datemath, kbn) {
     * Converts @date into µs since Epoch time (Warpscript tick format)
     ***********************************************************************************/
     function convertToWarp10Time(date) {
-      date = datemath.parse(date);
+      date = dateMath.parse(date);
       return date * 1000;
     }
 

--- a/warp10/queryCtrl.js
+++ b/warp10/queryCtrl.js
@@ -3,7 +3,7 @@ define([
   'lodash',
   'app/core/utils/datemath',
 ],
-function (angular, _, datemath) {
+function (angular, _, dateMath) {
   'use strict';
 
   var module = angular.module('grafana.controllers');
@@ -61,8 +61,8 @@ function (angular, _, datemath) {
     };
 
     $scope.linkToWarp = function() {
-      var from = datemath.parse($scope.dashboard.time.from);
-      var to = datemath.parse($scope.dashboard.time.to);
+      var from = dateMath.parse($scope.dashboard.time.from);
+      var to = dateMath.parse($scope.dashboard.time.to);
 
 
 


### PR DESCRIPTION
Fix dateMath case, except for JS file download
Rename warp10/partials/query-options.html into warp10/partials/query.options.html to avoid 404 error